### PR TITLE
MDEV-10832 Out of tree build: mysql_install_db to see all .sql files.

### DIFF
--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -291,7 +291,7 @@ then
   fi
   srcpkgdatadir=`find_in_basedir --dir fill_help_tables.sql share share/mysql`
   buildpkgdatadir=$srcpkgdatadir
-  if test -z "$pkgdatadir"
+  if test -z "$srcpkgdatadir"
   then
     cannot_find_file fill_help_tables.sql $basedir/share $basedir/share/mysql
     exit 1


### PR DESCRIPTION
```
    One line in mysql_install_db.sh was left unfixed.
```
